### PR TITLE
Nil columns for associations in tables

### DIFF
--- a/features/active_cucumber/create_many.feature
+++ b/features/active_cucumber/create_many.feature
@@ -30,6 +30,15 @@ Feature: ActiveCucumber.create_many
     And the database contains the show "Star Trek TNG"
 
 
+  Scenario: creating associated objects with a nil value
+    When running "ActiveCucumber.create_many Show, table" with this table:
+      | DIRECTOR         | NAME          |
+      |                  | Directionless |
+      | Gene Roddenberry | Star Trek TNG |
+    Then the database contains the given shows
+    And "Directionless" does not have a director
+
+
   Scenario: creating associated objects that depend on other associated objects
     When running "ActiveCucumber.create_many Episode, table" with this table:
       | GENRE           | SHOW          | NAME                  |

--- a/features/step_definitions/steps.rb
+++ b/features/step_definitions/steps.rb
@@ -11,7 +11,7 @@ end
 
 
 
-Then(/^running "([^"]+)" with this table:$/) do |code, table|
+When(/^running "([^"]+)" with this table:$/) do |code, table|
   @previous_table = table
   begin
     @error_happened = false
@@ -21,6 +21,10 @@ Then(/^running "([^"]+)" with this table:$/) do |code, table|
     @error_message = e.message
     @exception = e
   end
+end
+
+Then(/^"(.*?)" does not have a director$/) do |show_name|
+  expect(Show.find_by(name: show_name).director).to be nil
 end
 
 
@@ -34,6 +38,9 @@ Then(/^the database contains the given episodes$/) do
   ActiveCucumber.diff_all! Episode, @previous_table
 end
 
+Then(/^the database contains the given shows$/) do
+  ActiveCucumber.diff_all! Show, @previous_table
+end
 
 Then(/^the database contains the (\w+):$/) do |class_name, table|
   ActiveCucumber.diff_all! class_name.humanize.singularize.constantize, table

--- a/features/support/director.rb
+++ b/features/support/director.rb
@@ -1,0 +1,3 @@
+class Director < ActiveRecord::Base
+  belongs_to :show
+end

--- a/features/support/director.rb
+++ b/features/support/director.rb
@@ -1,3 +1,3 @@
 class Director < ActiveRecord::Base
-  belongs_to :show
+  has_many :show
 end

--- a/features/support/director.rb
+++ b/features/support/director.rb
@@ -1,3 +1,3 @@
 class Director < ActiveRecord::Base
-  has_many :show
+  has_many :shows
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -38,6 +38,12 @@ ActiveRecord::Schema.define do
     t.belongs_to :show
     t.datetime 'created_at'
   end
+
+  create_table :directors, force: true do |t|
+    t.string :name
+    t.belongs_to :show
+    t.datetime 'created_at'
+  end
 end
 
 
@@ -48,6 +54,7 @@ FactoryGirl.define do
 
   factory :show do
     name { Faker::Book.title }
+    director
   end
 
   factory :episode do
@@ -60,6 +67,10 @@ FactoryGirl.define do
     subscriber { Faker::Name.name }
     show
   end
+
+  factory :director do
+    name { Faker::Name.name }
+  end
 end
 
 
@@ -67,6 +78,7 @@ Before do
   Show.delete_all
   Episode.delete_all
   Subscription.delete_all
+  Director.delete_all
   @error_checked = false
 end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define do
 
   create_table :shows, force: true do |t|
     t.belongs_to :genre
+    t.belongs_to :director
     t.string :name
     t.datetime 'created_at'
   end
@@ -41,7 +42,6 @@ ActiveRecord::Schema.define do
 
   create_table :directors, force: true do |t|
     t.string :name
-    t.belongs_to :show
     t.datetime 'created_at'
   end
 end

--- a/features/support/episode_creator.rb
+++ b/features/support/episode_creator.rb
@@ -1,7 +1,6 @@
 class EpisodeCreator < ActiveCucumber::Creator
 
   def value_for_show show_name
-    return nil if show_name.blank?
     Show.find_by(name: show_name) || FactoryGirl.create(:show, name: show_name, genre: @genre)
   end
 

--- a/features/support/episode_creator.rb
+++ b/features/support/episode_creator.rb
@@ -1,6 +1,7 @@
 class EpisodeCreator < ActiveCucumber::Creator
 
   def value_for_show show_name
+    return nil if show_name.blank?
     Show.find_by(name: show_name) || FactoryGirl.create(:show, name: show_name, genre: @genre)
   end
 

--- a/features/support/show.rb
+++ b/features/support/show.rb
@@ -1,6 +1,6 @@
 class Show < ActiveRecord::Base
   belongs_to :genre
-  has_one :director
+  belongs_to :director
   has_many :episodes
   has_many :subscriptions
 end

--- a/features/support/show.rb
+++ b/features/support/show.rb
@@ -1,5 +1,6 @@
 class Show < ActiveRecord::Base
   belongs_to :genre
+  has_one :director
   has_many :episodes
   has_many :subscriptions
 end

--- a/features/support/show_creator.rb
+++ b/features/support/show_creator.rb
@@ -1,0 +1,8 @@
+class ShowCreator < ActiveCucumber::Creator
+
+  def value_for_director director_name
+    return nil if director_name.blank?
+    Director.find_by(name: director_name) || FactoryGirl.create(:director, name: director_name)
+  end
+
+end

--- a/features/support/show_cucumberator.rb
+++ b/features/support/show_cucumberator.rb
@@ -1,5 +1,10 @@
 class ShowCucumberator < ActiveCucumber::Cucumberator
 
+  def value_for_director
+    return '' unless director
+    director.name
+  end
+
   def value_for_genre
     genre.name
   end

--- a/features/support/show_cucumberator.rb
+++ b/features/support/show_cucumberator.rb
@@ -1,8 +1,7 @@
 class ShowCucumberator < ActiveCucumber::Cucumberator
 
   def value_for_director
-    return '' unless director
-    director.name
+    director ? director.name : ''
   end
 
   def value_for_genre

--- a/lib/active_cucumber/creator.rb
+++ b/lib/active_cucumber/creator.rb
@@ -19,7 +19,7 @@ module ActiveCucumber
       symbolize_attributes!
       @attributes.each do |key, value|
         next unless respond_to?(method = method_name(key))
-        if (result = send method, value)
+        if (result = send method, value) || value.nil?
           @attributes[key] = result if @attributes.key? key
         else
           @attributes.delete key
@@ -48,12 +48,17 @@ module ActiveCucumber
       key.downcase.parameterize.underscore.to_sym
     end
 
+    def normalized_value value
+      return nil if value.blank?
+      value
+    end
+
 
     # Makes the keys on @attributes be normalized symbols
     def symbolize_attributes!
       @attributes = {}.tap do |result|
         @attributes.each do |key, value|
-          result[normalized_key key] = value
+          result[normalized_key key] = normalized_value value
         end
       end
     end

--- a/lib/active_cucumber/creator.rb
+++ b/lib/active_cucumber/creator.rb
@@ -49,8 +49,7 @@ module ActiveCucumber
     end
 
     def normalized_value value
-      return nil if value.blank?
-      value
+      value.blank? ? nil : value
     end
 
 


### PR DESCRIPTION
Issue #1. This PR adds support for nil columns in fields that have a FactoryGirl association by default. E.g. the `movie` factory by default has a `director`, which is another factory. This PR enables the user to do something like this:

``` gherkin
Given the movie:
    | NAME      | DIRECTOR |
    | Star Wars |          |
```

``` ruby
Given(/^the movie:$/) do |table|
  @movie = ActiveCucumber.create_many(Movie, table).last
end
```

And the created movie's `director` field will be `nil`, as would be expected.

Please review!
@kevgo
