### PR TITLE
Allow longer functions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,9 @@ AllCops:
 Layout/LineLength:
   Max: 100
 
+Metrics/MethodLength:
+  Max: 20
+
 # Security/Eval is enabled globally. Specific eval usage in test step definitions
 # is documented with inline rubocop:disable comments explaining the justification.
 

--- a/lib/active_cucumber/creator.rb
+++ b/lib/active_cucumber/creator.rb
@@ -15,7 +15,6 @@ module ActiveCucumber
     end
 
     # Returns the FactoryBot version of this Creator's attributes.
-    # rubocop:disable Metrics/MethodLength
     def factorybot_attributes
       symbolize_attributes!
       # Capture original keys and values before any transformations
@@ -39,7 +38,6 @@ module ActiveCucumber
       end
       @attributes
     end
-    # rubocop:enable Metrics/MethodLength
 
     private
 


### PR DESCRIPTION
10 lines is a _suggestion_, it shouldn't be a hard rule. If we want to provide nice error messages, we will have multi-line strings that can push us over the limit, while not exceeding the complexity intended by this rule.